### PR TITLE
remove argument throwing errors from `cites_db_download()`

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -45,7 +45,7 @@ cites_db_download <- function(tag = NULL, destdir = tempdir(),
   # }
   # cites_disconnect()
   # invisible(cites_db())
-  unlink(cites_path(), recursive = TRUE, force = TRUE, expand = FALSE)
+  unlink(cites_path(), recursive = TRUE, force = TRUE)
 
   tblname <- "cites_shipments"
 

--- a/R/onattach.R
+++ b/R/onattach.R
@@ -29,7 +29,7 @@ in_chk <- function() {
 #' }
 cites_db_delete <- function() {
   cites_disconnect()
-  unlink(cites_path(), recursive = TRUE, force = TRUE, expand = FALSE)
+  unlink(cites_path(), recursive = TRUE, force = TRUE)
 }
 
 

--- a/man/cites_db.Rd
+++ b/man/cites_db.Rd
@@ -4,7 +4,7 @@
 \alias{cites_db}
 \title{The local CITES database}
 \usage{
-cites_db(dbdir = cites_path())
+cites_db(dbdir = cites_path(), read_only = TRUE)
 }
 \arguments{
 \item{dbdir}{The location of the database on disk. Defaults to

--- a/man/cites_shipments.Rd
+++ b/man/cites_shipments.Rd
@@ -12,7 +12,7 @@ A \strong{dplyr} remote tibble (\code{\link[dplyr:tbl]{dplyr::tbl()}})
 \description{
 Returns a remote database table with all CITES shipment data.  This is the
 bulk of the data in the package and constitutes > 20 million records.  Loading
-the whole table into R via the \code{\link[dplyr:compute]{dplyr::collect()}} command will use over
+the whole table into R via the \code{\link[dplyr:collect]{dplyr::collect()}} command will use over
 3 GB of RAM, so you may want to pre-process data in the database, as in
 the examples below.
 }


### PR DESCRIPTION
I had to remove `expand = FALSE` to be able to download the db